### PR TITLE
Update LibretroWrapper.cs

### DIFF
--- a/Assets/Libretro/Scripts/Wrapper/LibretroWrapper.cs
+++ b/Assets/Libretro/Scripts/Wrapper/LibretroWrapper.cs
@@ -100,7 +100,7 @@ namespace SK.Libretro
 
         public void DeactivateAudio()
         {
-            AudioProcessor.DeInit();
+            AudioProcessor?.DeInit();
             AudioProcessor = null;
         }
 


### PR DESCRIPTION
This shouldn't be called when the wrapper as been destroyed. Added null check to make it not fail just in case.