### PR TITLE
Update ModelLibretroGameSetup.cs

### DIFF
--- a/Assets/3darcade/scripts/Model/ModelLibretroGameSetup.cs
+++ b/Assets/3darcade/scripts/Model/ModelLibretroGameSetup.cs
@@ -111,6 +111,11 @@ namespace Arcade
                                 _rendererComponent.material.SetColor("_EmissionColor", Color.white);
                                 if (useRunLoop) { InvokeRepeating("LibretroRunLoop", 0f, 1f / (float)Wrapper.Game.SystemAVInfo.timing.fps); }
                             }
+                            else
+                            {
+                                Wrapper.StopGame();
+                                Wrapper = null;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Bad function name again :p
If the game fails to start, call Wrapper.StopGame to do the cleanup. (I should add a destructor or a dispose/deinit method).